### PR TITLE
Fix bug in get_data_url

### DIFF
--- a/R/owid.R
+++ b/R/owid.R
@@ -64,7 +64,7 @@ get_data_url <- function(chart_id) {
 
   preload <- links[rvest::html_attr(links, "rel") == "preload"]
 
-  all_urls <- sprintf("https://ourworldindata.org%s", rvest::html_attr(preload, "href"))
+  all_urls <- rvest::html_attr(preload, "href")
 
   json_urls <- grep("json$", all_urls, value = TRUE)
 


### PR DESCRIPTION
The concatenation of "https://ourworldindata.org" is no longer needed due to a change in our API.

Fixes https://github.com/piersyork/owidR/issues/5