### PR TITLE
Addresses subscript out of bounds error

### DIFF
--- a/R/owid.R
+++ b/R/owid.R
@@ -153,9 +153,9 @@ owid <- function(chart_id = NULL, rename = NULL, tidy.date = TRUE, ...) {
     colnames(out)[4] <- if (!is.null(display_name)) display_name else metadata$name
 
     data_info <- vector(mode = "list", length = 1)
-    data_info[[1]]$source <- if (is.null(metadata$source)) "" else metadata$source
     data_info[[1]]$dataset_name <- metadata$name
     data_info[[1]]$display <- metadata$display
+    data_info[[1]]$source <- metadata$source
   } else {
     tables <- grep(".*\\.data\\.json$", data_urls, value = TRUE) %>%
       lapply(\(x) jsonlite::fromJSON(x))

--- a/R/owid.R
+++ b/R/owid.R
@@ -153,7 +153,7 @@ owid <- function(chart_id = NULL, rename = NULL, tidy.date = TRUE, ...) {
     colnames(out)[4] <- if (!is.null(display_name)) display_name else metadata$name
 
     data_info <- vector(mode = "list", length = 1)
-    data_info[[1]]$source <- metadata$source
+    data_info[[1]]$source <- if (is.null(metadata$source)) "" else metadata$source
     data_info[[1]]$dataset_name <- metadata$name
     data_info[[1]]$display <- metadata$display
   } else {

--- a/R/owid.R
+++ b/R/owid.R
@@ -11,9 +11,10 @@ globalVariables(c("name", "code", "years", "values", "entity", "year", ".", "tit
 #'
 check_internet <- function(url) {
   out <- FALSE
+  url_status <- httr::GET(url = url)
   if (!curl::has_internet()) {
     message("No internet connection available: returning blank data.table")
-  } else if (httr::http_error(url)) {
+  } else if (httr::http_error(url_status)) {
     message(paste0("Could not connect to ", url, ", site may be down. Returning blank data.table"))
   } else {
     out <- TRUE


### PR DESCRIPTION
I have found a partial fix for the error raised in #7. It seems to be related to metadata which doesn't contain a `source` attribute. I have successfully downloaded the datasets using `owid()` that previously returned the error using my proposed change. However, calling `owid_source()` now returns an error, I guess it's because of the missing `source` attribute. 

I have run some queries on the OWID API, and I can't see the `source` attribute in any of them, like these ones:

**Population density:** https://api.ourworldindata.org/v1/indicators/734429.metadata.json
**Carbon intensity of electricity generation:** https://api.ourworldindata.org/v1/indicators/817696.metadata.json

Maybe they have changed some attribute names? I see an attribute named `origins` that seems to contain the source information. 